### PR TITLE
ENH Add ability to render any image using a default picture template and automatically render retina and webp version

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -1,6 +1,29 @@
 ---
 Name: silverstripe-picture
 ---
-SilverStripe\Assets\Image:
+SilverStripe\Assets\Storage\DBFile:
   extensions:
     - Kinglozzer\SilverstripePicture\ImageExtension
+
+Kinglozzer\SilverstripePicture\Picture:
+  styles:
+    DefaultRender:
+      default:
+        - {method: 'noop'}
+        - {method: 'Retina', arguments: ['2x'], descriptor: '2x'}
+        - {method: 'Retina', arguments: ['3x'], descriptor: '3x'}
+      sources:
+        -
+          -
+            manipulations:
+            - {method: 'Convert', arguments: ['webp']}
+          -
+            manipulations:
+            - {method: 'Retina', arguments: ['2x']}
+            - {method: 'Convert', arguments: ['webp']}
+            descriptor: '2x'
+          -
+            manipulations:
+            - {method: 'Retina', arguments: ['3x']}
+            - {method: 'Convert', arguments: ['webp']}
+            descriptor: '3x'

--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,9 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
-        "silverstripe/assets": "^2",
-        "silverstripe/framework": "^5"
+        "php": "^8.1",
+        "silverstripe/assets": "^2.3",
+        "silverstripe/framework": "^5.3"
     },
     "autoload": {
         "psr-4": {

--- a/src/ImageExtension.php
+++ b/src/ImageExtension.php
@@ -2,7 +2,13 @@
 
 namespace Kinglozzer\SilverstripePicture;
 
+use Exception;
+use SilverStripe\Assets\Storage\DBFile;
 use SilverStripe\Core\Extension;
+use InvalidArgumentException;
+use SilverStripe\Assets\Conversion\FileConverterException;
+use Psr\Container\NotFoundExceptionInterface;
+use SilverStripe\Assets\Image;
 
 class ImageExtension extends Extension
 {
@@ -11,7 +17,9 @@ class ImageExtension extends Extension
      */
     public function allMethodNames(): array
     {
-        return array_map('strtolower', array_keys(Picture::config()->get('styles')));
+        $methods = array_map('strtolower', array_keys(Picture::config()->get('styles')));
+        $methods[] = 'retina';
+        return $methods;
     }
 
     /**
@@ -19,6 +27,110 @@ class ImageExtension extends Extension
      */
     public function __call(string $method, array $args = [])
     {
+        if ($method === 'Retina') {
+            return $this->Retina(...$args);
+        }
+
         return Picture::create($this->owner, strtolower($method));
+    }
+
+    /**
+     * Try to generate a retina versions of the image. If no retina version can be generated, return false.
+     * @param $factorStr A string representing the factor by which to increase the image dimensions.
+     *     Must be a float followed by "x" (e.g. "2x")
+     */
+    public function Retina(string $factorStr = '2x'): DBFile|false
+    {
+        if (preg_match('/^(\d+(\.\d+)?)x$/', $factorStr, $matches)) {
+            $factor = (float) $matches[1];
+        } else {
+            throw new InvalidArgumentException(
+                'Invalid factor provided to Retina method. Must be a float followed by "x" (e.g. "2x")'
+            );
+        }
+        $original = $this->getOwner();
+
+        $originalWidth = $original->getWidth();
+        $originalHeight = $original->getHeight();
+
+        $retina = $this->replayManipulations(
+            $original,
+            $factor,
+            $originalWidth,
+            $originalHeight
+        );
+
+        if ($retina === false) {
+            return false;
+        }
+
+        // Force the new image to render at the size of the original image
+        $retina = $retina
+            ->setAttribute('width', $originalWidth)
+            ->setAttribute('height', $originalHeight);
+
+        return $retina;
+
+    }
+
+    /**
+     * Replay all the image manipulations but increasing the sizes by the
+     * provided factor. As the image manipulation are replayed, the size of the
+     * image is compared to the      * target dimension. If resizing the image
+     * would lead to a degradation in quality, false is returned.
+     *
+     * @param $image The image to replay the manipulations on
+     * @param $factor The factor by which to increase the image dimensions e.g. 2x
+     * @param $targetWidth The width of the original image
+     * @param $targetHeight The height of the original image
+     */
+    private function replayManipulations(
+        DBFile|Image $image,
+        float $factor,
+        int $targetWidth,
+        int $targetHeight
+    ): DBFile|Image|false
+    {
+        $variantString = $image->getVariant();
+
+        // We've replayed all the manipulations and have run out of variants
+        if (empty($variantString)) {
+            return $image;
+        }
+
+        // Get version of this image without the last manipulation
+        $original = $this->replayManipulations($image->getFailover(), $factor, $targetWidth, $targetHeight);
+
+        // The previous manipulation failed to generate a suitable image
+        if ($original === false) {
+            return false;
+        }
+
+        // Check dimensions of the image to see if it's too small to generate suitable variant.
+        if (
+            $original->getWidth() < $targetWidth * $factor ||
+            $original->getHeight() < $targetHeight * $factor
+        ) {
+            return false;
+        }
+
+        // Parse the last manipulation
+        $variantStringList = explode('_', $variantString);
+        $lastVariantString = end($variantStringList);
+        $variant = $image->variantParts($lastVariantString);
+        $method = array_shift($variant);
+
+        // Replay the manipulation but doubling the sizes.
+        // Do nothing if the parameter is not an integer
+        $arguments = array_map(function ($arg) use ($factor) {
+            return is_int($arg) ? intval($arg * $factor) : $arg;
+        }, $variant);
+
+        // The variant name for converting between format is different from it's method name
+        if ($method == 'ExtRewrite') {
+            return $original->Convert($arguments[1]);
+        }
+
+        return $original->$method(...$arguments);
     }
 }

--- a/src/Img.php
+++ b/src/Img.php
@@ -4,6 +4,7 @@ namespace Kinglozzer\SilverstripePicture;
 
 use SilverStripe\Assets\Image;
 use SilverStripe\Assets\Storage\AssetContainer;
+use SilverStripe\Assets\Storage\DBFile;
 use SilverStripe\View\HTML;
 use SilverStripe\View\ViewableData;
 
@@ -17,14 +18,14 @@ class Img extends ViewableData
     /**
      * The default image for this <picture> element, to be rendered as a nested <img /> tag
      */
-    protected Image $defaultImage;
+    protected Image|DBFile $defaultImage;
 
     /**
      * A store of any manipulations performed on the default image
      */
     protected array $defaultImageManipulations = [];
 
-    public function __construct(Image $sourceImage, array $config)
+    public function __construct(Image|DBFile $sourceImage, array $config)
     {
         parent::__construct();
         $this->__srcsetProviderConstruct($sourceImage, $config);
@@ -65,7 +66,7 @@ class Img extends ViewableData
         return $attributes;
     }
 
-    public function getDefaultImage(): Image
+    public function getDefaultImage(): Image|DBFile
     {
         return $this->defaultImage;
     }

--- a/src/Source.php
+++ b/src/Source.php
@@ -3,6 +3,7 @@
 namespace Kinglozzer\SilverstripePicture;
 
 use SilverStripe\Assets\Image;
+use SilverStripe\Assets\Storage\DBFile;
 use SilverStripe\View\HTML;
 use SilverStripe\View\ViewableData;
 
@@ -17,7 +18,7 @@ class Source extends ViewableData
      */
     protected string $media;
 
-    public function __construct(Image $sourceImage, string $media, array $config)
+    public function __construct(DBFile $sourceImage, string $media, array $config)
     {
         parent::__construct();
         $this->__srcsetProviderConstruct($sourceImage, $config);
@@ -38,8 +39,6 @@ class Source extends ViewableData
             'media' => $this->media,
             'srcset' => $this->getImageCandidatesString(),
             'type' => $lastImage->getMimeType(),
-            'width' => $firstImage->getWidth(),
-            'height' => $firstImage->getHeight(),
         ];
 
         $this->extend('updateAttributes', $attributes);

--- a/templates/SilverStripe/Assets/Storage/DBFile_Image.ss
+++ b/templates/SilverStripe/Assets/Storage/DBFile_Image.ss
@@ -1,0 +1,1 @@
+$DefaultRender


### PR DESCRIPTION
WIP 

This is design to define a default Picture format and will update the core rendering logic so all images come with WEBP and retina versions.

It's also smart enough that if you resize a picture, it will try to create the matching retina version of your resize picture.

This will work for both images referenced in a template and images added to a WYSIWYG.

## Parent issue
- https://github.com/silverstripe/.github/issues/230

## Depends on
- https://github.com/silverstripe/silverstripe-assets/pull/596
- https://github.com/silverstripe/silverstripe-framework/pull/11217